### PR TITLE
Configure Kafka topic partitions and listener concurrency

### DIFF
--- a/kafka-essentials/src/main/java/io/github/etr/courses/kafka/KafkaTopicConfig.java
+++ b/kafka-essentials/src/main/java/io/github/etr/courses/kafka/KafkaTopicConfig.java
@@ -1,0 +1,21 @@
+package io.github.etr.courses.kafka;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    private static final String STOCK_PRICE_UPDATE_TOPIC = "stock.price.update";
+
+    @Bean
+    public NewTopic stockPriceUpdateTopic() {
+        return TopicBuilder.name(STOCK_PRICE_UPDATE_TOPIC)
+                .partitions(4)
+                .replicas(1) // Defaulting to 1 replica as it's common for local/dev setups.
+                             // Production environments usually have 3.
+                .build();
+    }
+}

--- a/kafka-essentials/src/main/java/io/github/etr/courses/kafka/trend/analysis/TrendAnalyzer.java
+++ b/kafka-essentials/src/main/java/io/github/etr/courses/kafka/trend/analysis/TrendAnalyzer.java
@@ -15,7 +15,7 @@ public class TrendAnalyzer {
     private static final String STOCK_PRICE_UPDATE_TOPIC = "stock.price.update";
 
     @SneakyThrows
-    @KafkaListener(topics = STOCK_PRICE_UPDATE_TOPIC, groupId = "trend-analyzers")
+    @KafkaListener(topics = STOCK_PRICE_UPDATE_TOPIC, groupId = "trend-analyzers", concurrency = "4")
     public void analyzeStockPriceUpdate(String message) {
         log.info(green("Received message stock price update message: " + message));
         Thread.sleep(1000);


### PR DESCRIPTION
- Create KafkaTopicConfig to define 'stock.price.update' topic with 4 partitions.
- Update TrendAnalyzer's KafkaListener concurrency to 4.
- Verified StockPriceProvider already uses ticker as message key.